### PR TITLE
Fix TikZ library requirements for EM mediation diagram

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,7 +17,7 @@
 \usepackage{csquotes}
 \usepackage[most]{tcolorbox}
 \usepackage{tikz}
-\usetikzlibrary{patterns,decorations.pathmorphing,arrows.meta,positioning}
+\usetikzlibrary{patterns,decorations.pathmorphing,arrows.meta,positioning,calc}
 \usepackage{hyperref}
 
 \hypersetup{


### PR DESCRIPTION
## Summary
- add the TikZ `calc` library to the document preamble so the EM mediation diagram builds correctly

## Testing
- not run (latexmk not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3b4cad060833389fd66d95c18fea3