### PR TITLE
Add first-principles positioning and λτ decision map preview to introduction

### DIFF
--- a/sections/01_introduction.tex
+++ b/sections/01_introduction.tex
@@ -7,6 +7,33 @@ However, a complementary mechanism arises from discrete collision events: backgr
 These cannot be captured by Gaussian noise models alone.
 Instead, they produce intermittent heating signatures that are invisible to $S_E(\omega)$ alone.
 
+\paragraph{Positioning (complementary to empirical reviews).}
+Empirical surveys such as Brownnutt \emph{et al.} (2015)~\cite{Brownnutt2015} map the experimental
+landscape via field spectra $S_E(\omega)$ and heating rates; they are descriptive
+and data--driven. Our aim here is \emph{first principles categorization}:
+to explain why distinct microscopic mechanisms \emph{must} yield distinct
+\emph{statistical} signatures in ion heating, and to identify the observables
+that separate them most powerfully.
+
+\paragraph{Unifying idea.}
+All mechanisms couple through the same electromagnetic Green tensor
+$G(\mathbf r_0,\mathbf r;\omega)$ that encodes trap geometry and materials.
+What differs is the \emph{statistics of the source currents} $J(\mathbf r,t)$.
+Dense, weakly coupled sources $\Rightarrow$ Gaussian statistics (CLT) and
+Lindblad diffusion; rare, independent impulses $\Rightarrow$ compound--Poisson
+jumps with rate $\lambda$ and jump distribution set by scattering physics;
+heavy--tailed outliers give L\'evy--stable behavior. The mediation by $G$ is
+universal; the categorization rests on the statistics of $J$.
+
+\paragraph{Predictive consequence for experiments.}
+A single dimensionless control parameter, $\lambda\tau$ (event rate $\lambda$,
+interrogation time $\tau$), selects the informative observables:
+$\lambda\tau\gg1$ favors spectral methods; $\lambda\tau\sim1$ calls for higher
+cumulants and Allan variance; $\lambda\tau\ll1$ exposes waiting--time statistics
+and jump-size histograms. Table~\ref{tab:discriminants} summarizes this
+\emph{decision map}; Sec.~\ref{sec:inference_protocol} provides a stroboscopic
+protocol sized for statistical power.
+
 Both motional heating from electromagnetic field fluctuations and
 dephasing from collisional perturbations can be derived within the general
 framework of translation-covariant open-system dynamics.


### PR DESCRIPTION
## Summary
- add a positioning paragraph contrasting the paper's first-principles categorization with empirical surveys such as Brownnutt et al. (2015)
- highlight the universal electromagnetic Green tensor mediation and the role of source-current statistics in distinguishing mechanisms
- foreshadow the λτ decision map, relevant observables, and the Sec. 8 inference protocol

## Testing
- latexmk -pdf main.tex *(fails: `latexmk` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4aab72c2c8333be8f509eaf3cfebd